### PR TITLE
docs: add explicit `serve` subcommand for v3.7.0 CLI breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 * `--workspace`：指定工作空间文件夹路径，在宿主机上通过 `-v` 挂载到容器中
 * `--accessAuthCode`：指定访问授权码
 
-更多的参数可参考 `--help`。下面是一条启动命令示例：
+更多的参数可参考 `serve --help`。下面是一条启动命令示例：
 
 ```bash
 docker run -d \
@@ -40,6 +40,7 @@ docker run -d \
   -p 6806:6806 \
   -e PUID=1001 -e PGID=1002 \
   apkdv/siyuan-unlock \
+  serve \
   --workspace=workspace_dir_container \
   --accessAuthCode=xxx
 ```
@@ -61,6 +62,7 @@ docker run -d \
   -p 6806:6806 \
   -e PUID=1001 -e PGID=1002 \
   apkdv/siyuan-unlock \
+  serve \
   --workspace=/siyuan/workspace/ \
   --accessAuthCode=xxx
 ```
@@ -74,7 +76,7 @@ version: "3.9"
 services:
   main:
     image: apkdv/siyuan-unlock
-    command: ['--workspace=/siyuan/workspace/', '--accessAuthCode=${AuthCode}']
+    command: ['serve', '--workspace=/siyuan/workspace/', '--accessAuthCode=${AuthCode}']
     ports:
       - 6806:6806
     volumes:


### PR DESCRIPTION
SiYuan v3.7.0 (2026-06-16) 引入了 CLI 子命令架构
([siyuan-note/siyuan#17866](https://github.com/siyuan-note/siyuan/issues/17866))，
内核不再接受裸 flag 启动，必须显式指定 `serve` 子命令。

当前 README 的 Docker 示例使用旧语法，用户直接复制会报错：

```
Error: unknown flag: --accessAuthCode
```

### 参考

- 上游 breaking change 公告：https://github.com/siyuan-note/siyuan/issues/17866