### PR TITLE
feat: publish .deb packages in desktop release

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -24,6 +24,7 @@ jobs:
             goarch: "amd64"
             cc_path: "x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc"
             suffix: "linux.tar.gz"
+            deb_suffix: "linux.deb"
           - os: ubuntu-22.04
             name: ubuntu build linux.AppImage
             kernel_path: "../app/kernel-linux/SiYuan-Kernel"
@@ -34,6 +35,7 @@ jobs:
             goarch: "amd64"
             cc_path: "x86_64-linux-musl-cross/bin/x86_64-linux-musl-gcc"
             suffix: "linux.AppImage"
+            deb_suffix: ""
           - os: ubuntu-22.04
             kernel_path: "../app/kernel-linux-arm64/SiYuan-Kernel"
             build_mode: "-buildmode=pie"
@@ -43,6 +45,7 @@ jobs:
             goarch: "arm64"
             cc_path: "aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc"
             suffix: "linux-arm64.tar.gz"
+            deb_suffix: "linux-arm64.deb"
           - os: macos-latest
             kernel_path: "../app/kernel-darwin/SiYuan-Kernel"
             build_mode: ""
@@ -51,6 +54,7 @@ jobs:
             goos: "darwin"
             goarch: "amd64"
             suffix: "mac.dmg"
+            deb_suffix: ""
           - os: macos-latest
             kernel_path: "../app/kernel-darwin-arm64/SiYuan-Kernel"
             build_mode: ""
@@ -59,6 +63,7 @@ jobs:
             goos: "darwin"
             goarch: "arm64"
             suffix: "mac-arm64.dmg"
+            deb_suffix: ""
           - os: windows-latest
             kernel_path: "../app/kernel/SiYuan-Kernel.exe"
             build_mode: ""
@@ -69,6 +74,7 @@ jobs:
             mingwsys: "MINGW64"
             goarch: "amd64"
             suffix: "win.exe"
+            deb_suffix: ""
 
     steps:
       - name: Verify official repository
@@ -244,6 +250,20 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: ${{ github.workspace }}/siyuan-note/siyuan/app/build/siyuan-*-${{ matrix.config.suffix }}
           name: siyuan-unlock-${{ github.event.inputs.version }}-${{ matrix.config.suffix }}
+          allowUpdates: true
+          omitBody: true
+          omitName: true
+          tag: ${{ github.event.inputs.version }}
+          replacesArtifacts: true
+
+      - name: Upload .deb packages
+        if: ${{ matrix.config.deb_suffix != '' }}
+        uses: ncipollo/release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: ${{ github.workspace }}/siyuan-note/siyuan/app/build/siyuan-*-${{ matrix.config.deb_suffix }}
           allowUpdates: true
           omitBody: true
           omitName: true


### PR DESCRIPTION
### What

Publish the Linux `.deb` packages that the desktop release **already builds**:

* `siyuan-<version>-linux.deb`
* `siyuan-<version>-linux-arm64.deb`

### Why

`pnpm run dist-linux` / `dist-linux-arm64` use siyuan's own `electron-builder-linux*.yml`, where `linux.target` already lists `deb`. Both packages are created in every release run under `app/build/`, but the upload step only picks the artifact matching `matrix.config.suffix`, so the `.deb` files are thrown away.

The current assets show it: v3.8.3 ships `siyuan-3.8.3-linux.tar.gz` and `siyuan-3.8.3-linux.AppImage`, but no `siyuan-3.8.3-linux.deb`, although the deb was built in that same job.

This is the format that was asked for in #26 and #30.

### How

* add a `deb_suffix` field to the matrix (`linux.deb` / `linux-arm64.deb`, empty for the rows that produce no deb)
* add one more `ncipollo/release-action` step, skipped when `deb_suffix` is empty, uploading `siyuan-*-${deb_suffix}`

No build step is added or changed, so a release does not get slower -- only the files that are already built get uploaded. `.rpm` comes out of the same config but is deliberately out of scope here.

### Testing

The identical change is running in my fork (`expoli/siyuan-unlock@a6ed2f456`). Release v3.8.0 of that fork contains `siyuan-3.8.0-linux.deb` and `siyuan-3.8.0-linux-arm64.deb`; they were uploaded by run https://github.com/expoli/siyuan-unlock/actions/runs/31957328109, where the added step succeeded on both Linux rows and was skipped on the AppImage row. This workflow can only run in the official repository, so that fork run is the end-to-end evidence.

### 中文说明

思源自身的 electron-builder 配置里 `linux.target` 已经包含 `deb`，所以每次发布其实都生成了 `siyuan-<version>-linux.deb` 与 `-linux-arm64.deb`，只是上传时按 `matrix.config.suffix` 只挑了 tar.gz / AppImage，deb 被丢掉（v3.8.3 的资产里确实没有 deb）。本 PR 只补一个上传步骤：矩阵加 `deb_suffix` 字段 + 新增一步 `ncipollo/release-action`，不新增也不修改任何构建步骤，因此发布耗时不变。已在 fork 上实测通过。
